### PR TITLE
[AIRFLOW-6169] Avoid unnecessary int-to-float conversion

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -216,11 +216,11 @@ def scale_time_units(time_seconds_arr, unit):
     Convert an array of time durations in seconds to the specified time unit.
     """
     if unit == 'minutes':
-        return list(map(lambda x: x * 1.0 / 60, time_seconds_arr))
+        return list(map(lambda x: x / 60, time_seconds_arr))
     elif unit == 'hours':
-        return list(map(lambda x: x * 1.0 / (60 * 60), time_seconds_arr))
+        return list(map(lambda x: x / (60 * 60), time_seconds_arr))
     elif unit == 'days':
-        return list(map(lambda x: x * 1.0 / (24 * 60 * 60), time_seconds_arr))
+        return list(map(lambda x: x / (24 * 60 * 60), time_seconds_arr))
     return time_seconds_arr
 
 


### PR DESCRIPTION
### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6169
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

The `x * 1.0` statements in `utils.dates.scale_time_units` were to convert int to float so that the division operations can work as expected. But since we're migrating to Py3, this is no longer an issue, and we don't need to do the explicit type conversion anymore

### Tests

- [ =x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

Existing tests suffice.
